### PR TITLE
Added testing tracking for parameters for ML runs and simulate cubesat GSD degrading 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ Collection of software tools for multispectral image analysis and model testing.
 
 # Features
 - Cross-reference FIRMS fire event/EoNet and query via Copernicus's process API.
-- Run VGG model on labeled (fire/no fire) data.
+- Run ResNet50 model on labeled (fire/no fire) data.
+- Experiment tracking with automatic JSON config/results output
+- CubeSat GSD simulation (10m Sentinel-2 → 85m degradation)
 - Preprocess RGB-NIR algorithm with advanced fusion techniques
 - Optional NIR channel support for RGB-NIR 4 channel tensor model.
 - Cloud mask preprocessing to check cloud coverage threshold before wildfire inference.
@@ -128,59 +130,74 @@ uv run src/main.py [OPTIONS]
 ```
 
 ### Available Options
+
+#### Model Training
 - `--run-model`: Run the wildfire classification model.
+- `--epochs N`: Number of training epochs (default: 12)
+- `--use-nir`: Enable the 4-channel (RGB+NIR) model (Note: Not supported when using `--use-gcs`)
+- `--use-mixed-res`: Enable mixed resolution operations during training
+- `--fusion-technique {enhanced_red,hsv,none}`: RGB-NIR fusion technique (default: enhanced_red)
+- `--fusion-alpha FLOAT`: Alpha parameter for enhanced_red fusion, 0-1 (default: 0.5)
+- `--degrade-gsd`: Degrade imagery to CubeSat GSD (~85m from 10m Sentinel-2)
+- `--use-gcs`: Stream training data from Google Cloud Storage
+
+#### Data Acquisition
 - `--nasa-firms`: Fetch data availability from NASA FIRMS API.
-- `--setup-auth`: Set up OAuth2 authentication for Copernicus.
-- `--batch-download`: Download images from Flickr using Selenium.
 - `--eonet-crossref`: Fetch wildfire data from the EONET API and save it locally.
 - `--copernicus-query`: Query Sentinel-2 and Sentinel-1 data from Copernicus.
 - `--coordinates MIN_LON MIN_LAT MAX_LON MAX_LAT`: Specify a bounding box for the query.
 - `--time-range FROM TO`: Specify a time range for the query (e.g., `2023-01-01T00:00:00Z 2023-01-03T23:59:59Z`).
-- `--use-nir`: Enable the 4-channel (RGB+NIR) model (Note: Not supported when using `--use-gcs`)
-- `--use-gcs`: Stream training data from Google Cloud Storage
+- `--batch-download`: Download images from Flickr using Selenium.
+- `--process-sen2fire`: Convert Sen2Fire dataset to a state to be processed by the pipeline
+
+#### MLOps & Quality Control
 - `--multimodal-qc`: Run multimodal quality control checks using Gemini 2.0
 - `--qc-path PATH`: Path to folder for QC processing (e.g., 'sen2fire/to_qc' or 'eonet_fire_events/to_process')
 - `--cloud-mask`: Export OmniCloudMask models to ONNX and test cloud coverage assessment on labeled data
-- `--process-sen2fire`: Convert Sen2Fire dataset to a state to be processed by the pipeline
 - `--upload-labeled`: Upload labeled data to GCS after running cleanup
 - `--download-labeled`: Download labeled data from GCS to local filesystem
+
+#### Other
+- `--setup-auth`: Set up OAuth2 authentication for Copernicus.
+- `--compress-image PATH`: Test CCDS compression on .NEF image
 
 ### Examples
 1. **Run the wildfire classification model**:
    ```bash
-   uv run main.py --run-model
+   uv run src/main.py --run-model
    ```
 
-2. **Fetch wildfire data from the EONET API**:
+2. **Training with CubeSat GSD simulation**:
    ```bash
-   uv run main.py --eonet-crossref
+   uv run src/main.py --run-model --degrade-gsd
    ```
 
-3. **Query Sentinel data with a bounding box and time range**:
+3. **Training with custom epochs and mixed resolution**:
    ```bash
-   uv run main.py --copernicus-query --coordinates -59.75 -19.91 -58.72 -19.06 --time-range 2023-01-01T00:00:00Z 2023-01-03T23:59:59Z
+   uv run src/main.py --run-model --epochs 20 --use-mixed-res
    ```
 
-4. **Download images using Selenium**:
+4. **Training with HSV fusion technique**:
    ```bash
-   uv run main.py --batch-download
-   ```
-5. **Run the wildfire classification model with simulated NIR**:
-   ```bash
-   uv run main.py --run-model --use-nir
+   uv run src/main.py --run-model --fusion-technique hsv --fusion-alpha 0.6
    ```
 
-6. **Run the model using Google Cloud Storage**:
+5. **Full training with all options**:
    ```bash
-   uv run main.py --run-model --use-gcs
+   uv run src/main.py --run-model --epochs 20 --use-mixed-res --degrade-gsd --fusion-technique enhanced_red
    ```
 
-7. **Test cloud mask preprocessing on labeled data**:
+6. **Fetch wildfire data from the EONET API**:
    ```bash
-   uv run main.py --cloud-mask
+   uv run src/main.py --eonet-crossref
    ```
-# Resources
-- [Deep Learning in OpenCV](https://github.com/opencv/opencv/wiki/Deep-Learning-in-OpenCV)
-- [VGG Onnx How To](https://github.com/onnx/models/blob/main/validated/vision/classification/vgg/train_vgg.ipynb)
-- [ImageNet Demo](https://navigu.net/#imagenet)
-- [Satellite Deep Learning Techniques](https://github.com/satellite-image-deep-learning/techniques)
+
+7. **Query Sentinel data with a bounding box and time range**:
+   ```bash
+   uv run src/main.py --copernicus-query --coordinates -59.75 -19.91 -58.72 -19.06 --time-range 2023-01-01T00:00:00Z 2023-01-03T23:59:59Z
+   ```
+
+8. **Test cloud mask preprocessing on labeled data**:
+   ```bash
+   uv run src/main.py --cloud-mask
+   ```

--- a/progress_counter/locations_ledger.json
+++ b/progress_counter/locations_ledger.json
@@ -1,5 +1,5 @@
 {
-  "current_event_index": 2025,
+  "current_event_index": 2565,
   "events": {
     "grzrvxvryxfp": {
       "locations_generated": 0,
@@ -5539,6 +5539,3786 @@
       }
     },
     "gxvzbzcruxfz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrgzcxbzfxvr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrgzcxfxyrfr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v4vf159shdg0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v4vccpusr0jp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrfzyxfxfryp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrfzyzgzgzbx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrfzyzupzzur": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrfzzpcpgpfr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrfzzpczvrvp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrfzzpvrbxgp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrfzzrgpurvp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vruruzgrcrbr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrurypypupgp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrvpyrzxbzzr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrvpyxvpzzuz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrvzbpypuzyx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrvzbrbrypgz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrvzbrfpcpuz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vryzzrbxbzzx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vryzzrgpgrzp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "szz79fw36c98": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "szxtuxj9bfu7": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v02eyxndcywx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v093b6f4nkkd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v093b25muug1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v44q3d52d2zm": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v44q39j9eyu1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "tp46p6bed1cn": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "tp46p3b8vyxv": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "tp5jf9yu0xh5": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "tp5jddxyvtve": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "tp5jdgcetd7m": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v45v19w7wk66": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v45ucy8s5yzg": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v4h6bgygg7qy": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v4h6c10chnzg": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v1szs25e04ym": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v1szkmt07ztd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "v1mdnvvmev4t": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vmxk4jss20t6": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ub1met6x9ubq": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ub1mee7wehdd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "uc3rkj6s9kwc": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ub1kjkv5neqb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ub1kjs5ek6wy": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ubcep282vtc8": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "szuz9kj5m5xr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ubttbtf7d0hz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ubttbeerryuv": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "szygyvwzc3qh": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "szygz425309b": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "szygznnsg3p5": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "szygz4zb7pdt": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u96nku41z4dh": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u96nkvr4nnqz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u96nm0fbk4ev": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8g4nb2j4hf6": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u97e63qwxm27": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u97e4w12vp0m": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u978zegp2p7z": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u978z8te9qy6": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u978zc8wz9p9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u9jjrphnq29h": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u9jjrrsjtwtk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8vqy4e425hr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mmwrmnwh5f": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mmx746yjuu": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mmxmr9rv3r": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mmxe2vhxg6": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mt3p4zwr5x": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mt3jk5dgqq": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mt6cse2d50": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8veesfxpr9x": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8vxgxegzrup": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8vxjw7z944k": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mtjvucbc7j": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mwys93nc51": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mwyddshqgs": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8vsx3w140s3": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mv0x7j0vtf": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mv630necg2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mv4r3681ww": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u9jv4zjr9utb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8vg7nbv76j2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8vg7hdkt39p": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8tfey27w6s6": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8tfeu3snnrs": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mv5zr6sgt6": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mvm2y1etz1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8tbwm1ts797": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8tbw74zfexu": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mvq8vfbwb1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8vfx5frvyym": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8vfx1gbmezh": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8mbxr2n3b4y": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8tvzw6uxhk1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8y415drvdn9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8w1csc56xch": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8w1cdfkcxtv": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qj40bq2xek": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qhfp16ser1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qj41q8tvue": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qhfprudp8m": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8y0fr2fu9pr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qpgkjks7u0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8y0s6q111x2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8w1kvxf3dcb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8w1m59h0j8p": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8wnqprs327t": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8wpxngrwux2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8w1z814sn7b": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8w1xw4k7m88": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8wnpdpcmd0v": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8wr2m4s4h3s": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8nm3rryzbb1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8ykcubtedk9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u9n3h246knn1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "sxyt2k5n0sv3": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qw27eed3uj": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qw23sxndzq": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qvcmy9j2nf": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qyd871zct0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qvdz7tcv8y": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qvdvs9tsm6": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8qyk5h872ck": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u9nutd6hedkc": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u9ncw93w7rnr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u9ncqxfr59vf": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8rp2nksw616": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8rp2hmzen5d": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8x00q60fr22": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8rp26vmhzxr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u9pn3ctdmzsm": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8p5g1w62n2s": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "u8rhe61sk3s4": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edkrukky12gn": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ekpx8sy4mxzc": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eet4ek91ngn2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5ts3hdtwbdhw": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxuxvrbrvxur": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eevxstbqbxsj": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ewxej2m6f1t1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ekpwbjntcr4h": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tzsd4kvpg5y": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "egbukmbs7hyy": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev2m7fjg17q6": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxfzypuxbzfx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5zcb3nnscm2n": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ewxt55sksbrv": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eeuc9tc0fc40": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evshsjkx67np": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "etxh2g89bc7m": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eeu0d9bgek3m": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev2q628vh4ft": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5wsfnfvw3sqj": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxvxczzpcryp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edscz7m3eckd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eewz0u858tgs": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5z96p1en8jqd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5zdpf8ns7yzx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg365c0s2c6c": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edug4fkfbm6c": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "kszr0vbj66th": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eemx16xm0rsg": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyxfrupgzuz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyxvxgzzryp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxfzvrvzyzyp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j0nbp0h04840": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyxfrzpfzyp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edtjtrbc2d9y": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyxfpzxupcz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyxbxcpzrux": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg2xc4jbkyxq": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eedfb0tx2db9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edtjvqez3tkg": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eeskrw1ky9kp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "esrhjh0xmcq3": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyxbpurbpgx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5smuh657wc6u": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyzgxyrzpyr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tk04nxzsw2w": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxurvpvpuzvz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5sqq710uscxu": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyzyrvzypur": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eds36yes2mbg": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eegdd3fbcqve": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "grzrvxzrbpvz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "egsfmd5wm66j": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eegexsz145f1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5twsv96b23w3": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eud3tk1tbjfr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5eyux9g853vx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg04f8q38gdk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eevc943jjsrs": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg8tk63zmmxd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyxurbrypzz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5mzfhvsedx6g": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eesydtxteu29": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eu9bcr3su530": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vpurfzvpuxcp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "sug6kmpvy6s8": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5ss7n041huqr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eey0wcw1pf04": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev2memgkyr96": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbh04b10hb5b": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "h97twmr86dgh": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyzuxvpurgp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ekprh5d095fv": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tt90dy1790f": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyzgzvzuzgz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5z0f8gg5uu32": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5xp86rj5nhrh": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edu8gptfxu0b": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyzcrcrzryx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tqk9081buq3": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5u37q41uxm57": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "tj351pwjp154": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ekyns2y1kz2c": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev2m8fd5rf8h": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev2cgvd91g87": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ees05kv828ts": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eetwby5ud891": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg964m85pqw8": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5wt48eb45bbq": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5t9d5b8ntkjh": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vpvxcrfzcpvp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tvqjq8pnd8j": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5t7rpt8bwdw9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eenuzn7k0emu": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev2bz3cm8uqz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5szhse69tjhq": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5t9pqnqe563z": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tk5x7cmyjje": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5t7x3dq5fet2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ewy64ctq5618": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg8trz6fxx5e": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg8kyyqshttd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "efbryvk1c7sr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg51qywyhxjg": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg8edhpzmq8y": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5subn8mpy22u": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tk3d5rhuqpy": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tc5717m16js": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tch70drx37h": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5zd57tk9btk5": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg56ej1t6m5j": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vpuxfzuryryz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5thg6y8fxwfd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j01bnb1b08j0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j2h258hb1b12": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tjnt5rth10f": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5sy8gvrqphmp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5suzb8tepyv5": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5twmhtywh6vx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxuxzxurzxup": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j20b0bp00b1b": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ee6r0qkqh7mz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eewydzb23ph7": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edkscg8kkk0d": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j2580bp0jbj0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5srq4kmyyu4r": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5srq4mc7qy0h": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5sv4c8e08y6x": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5ts28uk00m6e": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5v1r8sqcnkqf": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5xy6jggy0rex": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5v1r8mwzxykg": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tkk897nwmve": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "es52w0j7c0ej": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5wt8rprxeyu2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9wkb88s8gs": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9wkbxpf9gm": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9skupxj6z7": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9tj4chndh9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9tjhwxnw4k": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9tj5pekkut": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9wjy6tt6bx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9wjug9fve8": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev9stywjkpjb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9tnhrb417n": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9tn68srbjx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9sqevysn3v": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9sqdqff17x": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey98qze23whv": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eycspys554tn": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9v8tkex8w5": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9v8etxve0e": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9u8y1thyzm": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9vbb75he8k": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9u9n2h7pym": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9v95sr78ry": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9v94j79947": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eycu11qcrqkd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eycgcpxukupe": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eycu12ywb553": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eycgcrr3yks9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eycgcxtcntwf": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey9g3xqwr8kx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev9gfwyny092": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eyccmj3qbdvv": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eyccm0s4fnmp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eycct4sfmgs9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eyccjnuyzvz9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eyccjjmfvt4s": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eyccj5wygqm4": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eyccj7vq1gee": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eyccj6q4psvc": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eyccjds9mvv4": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey3brdyjb238": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey3br9p0ufkk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4h2cyz2sp7": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4h2cp3z15h": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4h1pbh4kyj": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4h31qdxfs7": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey459s57wjcp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evfn9tss3zmq": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evfn9vu7me6m": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4h3bjce0rv": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey61f8fxqg6v": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey61dx5u610y": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey6h70w9wuvb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey6h5nzc2r8p": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey45ekpmydcy": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey45e7pewfy5": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey45ed0c30yk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey45e8byxzqw": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evfjw19h9r8g": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evfnyq8ecc25": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evfjw3byxyqu": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evfnymtygdgu": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eydpx3dqj8pv": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eydpx2567kdc": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evdhzvce3h8x": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evdhzf7wqcjx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey6m0s4hz3j6": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey47cegfd266": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey47c9tn51gp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey47cdtn74en": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey47cu55v2tz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4m6u9m0zwg": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4m6vc34f46": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4m6gdx3gr4": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4m75czc3e7": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey42g8d7h6kf": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev6rkz1q4u3y": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev63r76d4c65": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey42zu6sx9h9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evfqxg7vefzc": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey42zfh1ks7f": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey48bp0gvcw0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev68bm1uy8sc": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev68b2jq16eu": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev68b3m3t5ep": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey6x9phn1v34": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey6x9jt408cm": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4d6jp1jue7": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evf8dqv34x0x": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eyfsgpk1fhrd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey49kex5ck7k": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey6yc0c4cn2w": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eydf341tjz02": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eydf30d8hw8s": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev4gf03c85wk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev4gf4pc3ee7": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4cyzf7h9n6": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eve006rkvbzv": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eve00etk07jp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evgh90k3wfw3": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evgh3pjw8tbj": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eve119k88sbt": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eve11ff2z2eq": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eve11cwhxkgw": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eve0fzfnhjcx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eve0fguwu3n5": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eve0ghq6uky7": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey51t9hwhdvc": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey51tgfuh2kh": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey50p58f19yr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evg79zrtbw1t": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evg7dn3v4ys1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey524hw1s0s5": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evg7dpzbj4wc": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey52ur10wuv5": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey5mku5p50y2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evekw4899hkx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey53qx64s3du": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey53w8scwfxe": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eves5dwt4f96": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eveegybyu4qk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey59k4wt89hq": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eveskzw8t0fy": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eveskvp9s741": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evesm5c1cx2w": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev7dj4kp3k35": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev7dj1kvu2dp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evgtn39jqq5g": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evesyxprrf31": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evesyy0jfqjt": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evesyg9dyvg2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev7vb72971bw": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ev7vbkdg4s3s": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eveys9gupfk8": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eyh00024egqb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evup8gb7dczn": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "evup8f64j1rm": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eesyyekk3y11": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eduy33wzwvqc": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edv2q93kcw0p": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edufmpnwn1n4": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "etgjbw2vw58y": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg56q4wsr10y": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edu9nc1d5qe8": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tv56zw4m9zk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eexn2mqr1xz2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vpyzbxgpfzfx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edv07uhp62cr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg8c9y6yye2h": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "etr1hcw5zfq0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "egmnjhj7dg93": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eexyh392yks9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ees3zng197zk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "esntbm6k5e87": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eehrz8der7p0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg0rx7wmb5xk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eesjupuvfcre": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eepxhdkk56yv": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ewymp6dvdcf9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "etfu99weps32": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eucjhfucyq0t": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbp2j0hbj84b": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "h8pbj8hbpbj8": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eepene1edhdj": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "em5pysun53z0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j2h8nb48p8p0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg3vrjsrhpe4": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eeewuvkn5jnx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg0zq2w8nvwg": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eed9yr60vpmq": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "etfptxf53unb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eu3xe6j2b1g8": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edwgp5tw1pbh": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "egbw18x1kxtz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j24b12nbh8hb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyrvxcryzcz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrupcxyryxvz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "egb4xbgfctd7": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg272up3m3q3": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "e7yx40q7sp6b": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "vrfrcpbxvpfx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ek83d7d2j0df": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j0p8jbp0p8j0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j258n2hbh800": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eeeftvfce9gm": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "euf9svm6dgkm": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eedshzxmqnpd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ewegmq9uygu6": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eue6dnwbexuz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "etpny7mbrpkx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eey2yt18ww2y": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eewrb8hnc4jb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbhb1bn0pb40": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "h8p80800n2nb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j0124b581b18": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hb5858424b10": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hb10nb52n8p2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eyjy1n0f18s9": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbp2j2hbn0h8": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbp2hb0bnbpb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eud6htvmk5qk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5wvc6zm6dr78": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eud4mx6ptwwk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg88bfzb65q4": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ewxmqvnypcje": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eu6p7855cc89": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j2h2j848pbn2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxvxzrzrcxfp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5y4ye9w71nwk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxyzypzzzrup": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "em4zqggd21vj": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "efbs69depdph": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "egb3wsdvfe2m": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eu6j8hreb1e1": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eudhv9krs7jw": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tt3kew6pdvb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxvxvpzpzzbp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j2hbpb4248n2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxypzxgrcxzr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5u1v6c42jmu2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j240j0p24000": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edzbzj6xh363": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j252n8121b08": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ey4c6st4ghb5": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg0b0puyvwqb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg25zn1ct9p2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eerbk7bbmwux": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eepwc2s63m2x": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gzuzyzzzgryx": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eet78qurd6sb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg3k11t4k84f": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "etqbre9d60hd": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "etp6s9qpr6z3": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "edvcdpffx49r": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j2425010j8h0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j248485bj0h8": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbj8480bj2hb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hb024b1bh218": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbp2hb58h2n0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbp2h0p2n21b": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbp20bp840p2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbp8j8p0h0n0": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbp2n042nb42": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbpb1840h050": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbp2hb5bjb02": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j00b48p8n0n8": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbn0j2nbnbpb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5ye37yc4p3b2": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tk8v5nbf8r3": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbp258h05818": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j2n0h2481bnb": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbn0hbj2h840": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5teknsujm3nc": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5tt9bpk56nbp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j00b12n21b02": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5t9uuxud8eet": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "ewy6jwqc45sq": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5wkwqnkfywbj": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg2uhz7krgph": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eud6m0h98xjk": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "j2j8pb420002": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "hbp8n2000012": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxvzgpfzyxbp": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "5wtjh6cb322v": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxgzgzuxyrbz": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxupfrbrfxcr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "gxypfryxyzyr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "egcm1yd4runj": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eud0esymmkxe": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eduxur3qx8x5": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg35gjycbcgr": {
+      "locations_generated": 0,
+      "locations_processed": 1,
+      "location_status": {
+        "0": "completed"
+      }
+    },
+    "eg90qbue9wyb": {
       "locations_generated": 0,
       "locations_processed": 1,
       "location_status": {

--- a/src/experiment_tracker.py
+++ b/src/experiment_tracker.py
@@ -1,0 +1,142 @@
+"""Experiment tracking for model training runs."""
+
+import os
+import json
+import logging
+from datetime import datetime
+from typing import Dict, Any, Optional
+from paths import resolve_path
+
+logger = logging.getLogger(__name__)
+
+
+def generate_experiment_id() -> str:
+    """Generate unique experiment ID based on timestamp.
+
+    Returns:
+        str: Experiment ID in format 'exp_YYYYMMDD_HHMMSS'
+    """
+    return f"exp_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+
+def create_experiment_directory(experiment_id: str) -> str:
+    """Create directory for experiment outputs.
+
+    Args:
+        experiment_id: Unique experiment identifier
+
+    Returns:
+        str: Path to experiment directory
+    """
+    exp_dir = resolve_path(f"experiments/{experiment_id}")
+    os.makedirs(exp_dir, exist_ok=True)
+    return exp_dir
+
+
+def save_experiment_config(
+    experiment_id: str,
+    preprocessing_config: Dict[str, Any],
+    model_config: Dict[str, Any],
+    training_config: Dict[str, Any]
+) -> str:
+    """Save experiment configuration to JSON file.
+
+    Args:
+        experiment_id: Unique experiment identifier
+        preprocessing_config: Preprocessing parameters
+        model_config: Model architecture parameters
+        training_config: Training hyperparameters
+
+    Returns:
+        str: Path to saved config file
+    """
+    exp_dir = create_experiment_directory(experiment_id)
+
+    config = {
+        "experiment_id": experiment_id,
+        "timestamp": datetime.now().isoformat() + "Z",
+        "preprocessing": preprocessing_config,
+        "model": model_config,
+        "training": training_config
+    }
+
+    config_path = os.path.join(exp_dir, "config.json")
+    with open(config_path, 'w') as f:
+        json.dump(config, f, indent=2)
+
+    logger.info(f"Saved experiment config to {config_path}")
+    return config_path
+
+
+def save_experiment_results(
+    experiment_id: str,
+    results: Dict[str, Any],
+    model_filename: str,
+    plot_filename: str
+) -> str:
+    """Save experiment results and output file paths.
+
+    Args:
+        experiment_id: Unique experiment identifier
+        results: Training results (accuracy, loss metrics)
+        model_filename: Path to saved ONNX model
+        plot_filename: Path to saved training plot
+
+    Returns:
+        str: Path to saved results file
+    """
+    exp_dir = create_experiment_directory(experiment_id)
+
+    results_data = {
+        "experiment_id": experiment_id,
+        "results": results,
+        "outputs": {
+            "model_file": model_filename,
+            "plot_file": plot_filename
+        }
+    }
+
+    results_path = os.path.join(exp_dir, "results.json")
+    with open(results_path, 'w') as f:
+        json.dump(results_data, f, indent=2)
+
+    logger.info(f"Saved experiment results to {results_path}")
+    return results_path
+
+
+def load_experiment_config(experiment_id: str) -> Optional[Dict[str, Any]]:
+    """Load experiment configuration from JSON file.
+
+    Args:
+        experiment_id: Unique experiment identifier
+
+    Returns:
+        dict: Experiment configuration or None if not found
+    """
+    config_path = resolve_path(f"experiments/{experiment_id}/config.json")
+
+    if not os.path.exists(config_path):
+        logger.error(f"Experiment config not found: {config_path}")
+        return None
+
+    with open(config_path, 'r') as f:
+        return json.load(f)
+
+
+def load_experiment_results(experiment_id: str) -> Optional[Dict[str, Any]]:
+    """Load experiment results from JSON file.
+
+    Args:
+        experiment_id: Unique experiment identifier
+
+    Returns:
+        dict: Experiment results or None if not found
+    """
+    results_path = resolve_path(f"experiments/{experiment_id}/results.json")
+
+    if not os.path.exists(results_path):
+        logger.error(f"Experiment results not found: {results_path}")
+        return None
+
+    with open(results_path, 'r') as f:
+        return json.load(f)

--- a/src/main.py
+++ b/src/main.py
@@ -66,12 +66,19 @@ if __name__ == "__main__":
     parser.add_argument('--download-labeled', required=False, action='store_true', help="Download labeled data from GCS to local filesystem")
     parser.add_argument('--use-mixed-res', required=False, action='store_true', help="Enable mixed resolution operations during training")
     parser.add_argument('--epochs', required=False, type=int, default=12, help="Number of epochs for training")
+    parser.add_argument('--fusion-technique', required=False, type=str, default='enhanced_red', choices=['enhanced_red', 'hsv', 'none'], help="RGB-NIR fusion technique")
+    parser.add_argument('--fusion-alpha', required=False, type=float, default=0.5, help="Alpha parameter for enhanced_red fusion (0-1)")
+    parser.add_argument('--degrade-gsd', required=False, action='store_true', help="Degrade imagery to CubeSat GSD (~85m from 10m Sentinel-2)")
     parser.add_argument("--compress-image", required=False, type=str, help="Path to the input .NEF image")
 
     args = parser.parse_args()
     if args.run_model:
-        model.train(use_nir=args.use_nir, use_gcs=args.use_gcs, 
-                   use_mixed_res=args.use_mixed_res, epochs=args.epochs)
+        experiment_id = model.train(use_nir=args.use_nir, use_gcs=args.use_gcs,
+                                    use_mixed_res=args.use_mixed_res, epochs=args.epochs,
+                                    fusion_technique=args.fusion_technique,
+                                    fusion_alpha=args.fusion_alpha,
+                                    degrade_gsd=args.degrade_gsd)
+        print(f"\nTraining complete! Experiment ID: {experiment_id}")
     elif args.nasa_firms:
         nasa_firms_api()
     elif args.setup_auth:

--- a/src/mlops.py
+++ b/src/mlops.py
@@ -8,8 +8,6 @@ from typing import List, Optional
 import numpy as np
 import cv2
 
-from fetch import Source
-
 from google import genai
 from google.cloud import storage
 from paths import get_gcs_credentials_path, resolve_path
@@ -329,6 +327,8 @@ def run_multimodal_qc(use_gcs=False, input_path=None):
     if use_gcs:
         # Initialize GCS handler
         try:
+            from fetch import Source
+
             gcs_handler = GCSHandler()
             logging.info("Using GCS for multimodal QC")
 

--- a/src/model.py
+++ b/src/model.py
@@ -27,12 +27,14 @@ import logging
 from mlops import GCSHandler
 from paths import resolve_path, get_model_path
 from mixed_res_config import DEFAULT_MIXED_RES_CONFIG
+import experiment_tracker
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def train(validate=True, epochs=12, use_nir=False, use_gcs=False, 
-          use_mixed_res=False, mixed_res_config=None):
+def train(validate=True, epochs=12, use_nir=False, use_gcs=False,
+          use_mixed_res=False, mixed_res_config=None, fusion_technique='enhanced_red',
+          fusion_alpha=0.5, degrade_gsd=False):
     """
     Train CNN ResNet50 model on labeled data.
 
@@ -43,13 +45,20 @@ def train(validate=True, epochs=12, use_nir=False, use_gcs=False,
         use_gcs (bool): Whether to stream data from GCS.
         use_mixed_res (bool): Whether to apply mixed resolution operations during training.
         mixed_res_config (dict): Configuration for mixed resolution operations.
+        fusion_technique (str): RGB-NIR fusion technique ('enhanced_red', 'hsv', 'none').
+        fusion_alpha (float): Alpha parameter for enhanced_red fusion.
+        degrade_gsd (bool): Whether to degrade imagery to CubeSat GSD (~85m from 10m).
 
     Returns:
-        None
+        str: Experiment ID for this training run
     """
+    # Generate experiment ID
+    experiment_id = experiment_tracker.generate_experiment_id()
+    logger.info(f"Starting training experiment: {experiment_id}")
+
     X = []
     y = []
-    
+
     # Use default config if none provided
     if use_mixed_res and mixed_res_config is None:
         mixed_res_config = DEFAULT_MIXED_RES_CONFIG
@@ -60,13 +69,19 @@ def train(validate=True, epochs=12, use_nir=False, use_gcs=False,
             gcs = GCSHandler()
 
             # Pass GCS handler and mixed_res options to populate function
-            X, y = preprocess.populate(X, y, "labeled/yes", use_nir=use_nir, 
-                          gcs_handler=gcs, use_mixed_res=use_mixed_res, 
-                          mixed_res_config=mixed_res_config)
-            X, y = preprocess.populate(X, y, "labeled/no", use_nir=use_nir, 
-                          end=True, gcs_handler=gcs, 
+            X, y = preprocess.populate(X, y, "labeled/yes", use_nir=use_nir,
+                          gcs_handler=gcs, use_mixed_res=use_mixed_res,
+                          mixed_res_config=mixed_res_config,
+                          fusion_technique=fusion_technique,
+                          fusion_alpha=fusion_alpha,
+                          degrade_gsd=degrade_gsd)
+            X, y = preprocess.populate(X, y, "labeled/no", use_nir=use_nir,
+                          end=True, gcs_handler=gcs,
                           use_mixed_res=use_mixed_res,
-                          mixed_res_config=mixed_res_config)
+                          mixed_res_config=mixed_res_config,
+                          fusion_technique=fusion_technique,
+                          fusion_alpha=fusion_alpha,
+                          degrade_gsd=degrade_gsd)
 
         except Exception as e:
             logger.error(f"Failed to load data from GCS: {str(e)}")
@@ -74,11 +89,17 @@ def train(validate=True, epochs=12, use_nir=False, use_gcs=False,
     else:
         # Use local files with mixed resolution options
         X, y = preprocess.populate(X, y, resolve_path("data/labeled/yes"), use_nir=use_nir,
-                      use_mixed_res=use_mixed_res, 
-                      mixed_res_config=mixed_res_config)
-        X, y = preprocess.populate(X, y, resolve_path("data/labeled/no"), use_nir=use_nir, 
+                      use_mixed_res=use_mixed_res,
+                      mixed_res_config=mixed_res_config,
+                      fusion_technique=fusion_technique,
+                      fusion_alpha=fusion_alpha,
+                      degrade_gsd=degrade_gsd)
+        X, y = preprocess.populate(X, y, resolve_path("data/labeled/no"), use_nir=use_nir,
                       end=True, use_mixed_res=use_mixed_res,
-                      mixed_res_config=mixed_res_config)
+                      mixed_res_config=mixed_res_config,
+                      fusion_technique=fusion_technique,
+                      fusion_alpha=fusion_alpha,
+                      degrade_gsd=degrade_gsd)
 
     # TODO: Use numpy instead here
     X = [X[i] for i in range(min(len(X), len(y)))]
@@ -127,8 +148,11 @@ def train(validate=True, epochs=12, use_nir=False, use_gcs=False,
         top_model = bottom_model.output
         top_model = keras.layers.GlobalAveragePooling2D()(top_model)
         top_model = keras.layers.Dense(1024, activation='relu')(top_model)
+        top_model = keras.layers.Dropout(0.5)(top_model)
         top_model = keras.layers.Dense(1024, activation='relu')(top_model)
+        top_model = keras.layers.Dropout(0.5)(top_model)
         top_model = keras.layers.Dense(512, activation='relu')(top_model)
+        top_model = keras.layers.Dropout(0.3)(top_model)
         output = keras.layers.Dense(num_classes, activation='softmax')(top_model)
         return output
 
@@ -152,41 +176,98 @@ def train(validate=True, epochs=12, use_nir=False, use_gcs=False,
                                                      save_weights_only=True,
                                                      verbose=1)
 
+    early_stopping = tf.keras.callbacks.EarlyStopping(monitor='val_loss', patience=3)
+
     history = model.fit(X_train, y_train,
                         epochs=epochs,
                         validation_data=(X_test, y_test),
                         verbose=1,
                         initial_epoch=0,
                         shuffle=True,
-                        callbacks=[cp_callback])
+                        callbacks=[cp_callback, early_stopping])
 
     accuracy = history.history['accuracy']
     val_accuracy = history.history['val_accuracy']
     loss = history.history['loss']
     val_loss = history.history['val_loss']
-    export_to_onnx(model)
 
     if validate:
         test_loss, test_accuracy = model.evaluate(X_test, y_test)
         logger.info(f'Test accuracy: {test_accuracy:.4f}')
-        epochs = range(len(accuracy))
-        plt.plot(epochs, accuracy, 'r', label='Training accuracy')
-        plt.plot(epochs, val_accuracy, 'b', label='Validation accuracy')
+        epochs_range = range(len(accuracy))
+        plt.plot(epochs_range, accuracy, 'r', label='Training accuracy')
+        plt.plot(epochs_range, val_accuracy, 'b', label='Validation accuracy')
         plt.title('Training and validation accuracy')
         plt.legend(loc=0)
-        plt.figure()
-        plt.show()
 
-def export_to_onnx(model):
+        # Save experiment
+        exp_dir = experiment_tracker.create_experiment_directory(experiment_id)
+        plot_filename = os.path.join(exp_dir, "training_plot.png")
+        plt.savefig(plot_filename)
+
+        model_filename = os.path.join(exp_dir, f"model_{experiment_id}.onnx")
+        export_to_onnx(model, model_filename)
+
+        experiment_tracker.save_experiment_config(
+            experiment_id,
+            {
+                "use_nir": use_nir,
+                "dataset": {"total_samples": len(X), "train_samples": len(X_train), "test_samples": len(X_test), "source": "gcs" if use_gcs else "local"},
+                "mixed_resolution": {"enabled": use_mixed_res, **(mixed_res_config if use_mixed_res else {})},
+                "rgb_nir_fusion": {"technique": fusion_technique, "alpha": fusion_alpha},
+                "gsd_degradation": degrade_gsd,
+                "normalization": "dyn_zscore"
+            },
+            {
+                "base_model": resnet50.__class__.__name__,
+                "input_shape": list(model.input_shape[1:]),
+                "pretrained_weights": weights
+            },
+            {
+                "epochs": len(accuracy),
+                "optimizer": model.optimizer.__class__.__name__.lower(),
+                "loss": model.loss,
+                "train_test_split": len(X_test) / len(X)
+            }
+        )
+
+        experiment_tracker.save_experiment_results(
+            experiment_id,
+            {
+                "final_train_accuracy": float(accuracy[-1]),
+                "final_val_accuracy": float(val_accuracy[-1]),
+                "final_train_loss": float(loss[-1]),
+                "final_val_loss": float(val_loss[-1]),
+                "best_val_accuracy": float(max(val_accuracy)),
+                "best_val_accuracy_epoch": int(val_accuracy.index(max(val_accuracy))),
+                "test_accuracy": float(test_accuracy),
+                "test_loss": float(test_loss)
+            },
+            model_filename,
+            plot_filename
+        )
+
+        logger.info(f"Experiment {experiment_id} saved to {exp_dir}")
+
+        # plt.figure()
+        # plt.show()
+
+    return experiment_id
+
+def export_to_onnx(model, filename=None):
     """
     Export the trained model to ONNX format.
 
     Args:
         model (tf.keras.Model): The trained Keras model to be exported.
+        filename (str): Path to save the ONNX model. If None, uses default path.
 
     Returns:
         None
     """
+    if filename is None:
+        filename = get_model_path('zetane.onnx')
+
     input_signature = [
         tf.TensorSpec(
             shape=model.input_shape,
@@ -197,9 +278,9 @@ def export_to_onnx(model):
     onnx_model, _ = tf2onnx.convert.from_keras(
         model,
         input_signature=input_signature,
-        opset=13  # Specify ONNX opset version
+        opset=13
     )
-    onnx.save(onnx_model, get_model_path('zetane.onnx'))
+    onnx.save(onnx_model, filename)
 
 def run_inference(onnx_model=None, data_target=None):
     if onnx_model is None:

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -17,6 +17,29 @@ from mixed_res_config import DEFAULT_MIXED_RES_CONFIG
 # Set up logging
 logger = logging.getLogger(__name__)
 
+def degrade_to_cubesat_gsd(image: np.ndarray) -> np.ndarray:
+    """
+    Degrade Sentinel-2 imagery (10m GSD) to match CubeSat expected GSD (~85m).
+    This simulates the lower resolution data that will be captured on-orbit.
+
+    Degradation factor: 10m -> 85m = 8.5x downsampling
+
+    Args:
+        image: Input image at Sentinel-2 resolution (HxWxC)
+
+    Returns:
+        Degraded image at CubeSat GSD, upsampled back to original dimensions
+    """
+    h, w = image.shape[:2]
+
+    # Downsample by 8.5x using INTER_AREA (best for downsampling)
+    degraded = cv2.resize(image, (w//8, h//8), interpolation=cv2.INTER_AREA)
+
+    # Upsample back to original size using INTER_LINEAR (simulates lower quality data)
+    degraded = cv2.resize(degraded, (w, h), interpolation=cv2.INTER_LINEAR)
+
+    return degraded
+
 def random_resize_with_pad(image: np.ndarray, min_scale: float = 0.5, max_scale: float = 1.5) -> np.ndarray:
     """
     Randomly resize an image, then pad to maintain original dimensions.
@@ -215,7 +238,8 @@ class FusionOutput(BaseModel):
         return v
 
 def populate(X_array, y_array, path, use_nir=False, end=False, gcs_handler=None,
-             use_mixed_res=False, mixed_res_config=None):
+             use_mixed_res=False, mixed_res_config=None, fusion_technique='enhanced_red',
+             fusion_alpha=0.5, degrade_gsd=False):
     """Populates the input arrays with preprocessed images and labels.
 
     Args:
@@ -227,6 +251,9 @@ def populate(X_array, y_array, path, use_nir=False, end=False, gcs_handler=None,
         gcs_handler: Handler for Google Cloud Storage.
         use_mixed_res (bool): Whether to apply mixed resolution operations.
         mixed_res_config (dict): Configuration for mixed resolution operations.
+        fusion_technique (str): RGB-NIR fusion technique: 'enhanced_red', 'hsv', or 'none'.
+        fusion_alpha (float): Alpha value for enhanced_red fusion (default 0.5).
+        degrade_gsd (bool): Whether to degrade imagery to CubeSat GSD (~85m from 10m).
 
     Returns:
         tuple: A tuple containing the updated X_array and y_array.
@@ -249,6 +276,10 @@ def populate(X_array, y_array, path, use_nir=False, end=False, gcs_handler=None,
                     logger.warning(f"Could not decode {image_path}, skipping...")
                     continue
 
+                # Apply GSD degradation if requested (simulates CubeSat resolution)
+                if degrade_gsd:
+                    rgb = degrade_to_cubesat_gsd(rgb)
+
                 # IMPORTANT: Apply mixed resolution operations BEFORE resizing to fixed size
                 if use_mixed_res:
                     rgb = apply_mixed_resolution_ops([rgb], **mixed_res_config)[0]
@@ -267,7 +298,11 @@ def populate(X_array, y_array, path, use_nir=False, end=False, gcs_handler=None,
                     X_array.append(rgb_nir)
                 else:
                     try:
-                        fused_result = rgb_nir_fusion(rgb, use_enhanced_red=True)
+                        fused_result = rgb_nir_fusion(
+                            rgb,
+                            technique=fusion_technique,
+                            alpha=fusion_alpha
+                        )
                     except Exception as e:
                         logger.warning(f"{e}: issue with rgb nir fusion technique, skipping for {image_path}")
                         fused_result = rgb
@@ -286,6 +321,10 @@ def populate(X_array, y_array, path, use_nir=False, end=False, gcs_handler=None,
                 if rgb is None:
                     logger.warning(f"Could not read {image_path}, skipping...")
                     continue
+
+                # Apply GSD degradation if requested (simulates CubeSat resolution)
+                if degrade_gsd:
+                    rgb = degrade_to_cubesat_gsd(rgb)
 
                 # IMPORTANT: Apply mixed resolution operations BEFORE resizing to fixed size
                 if use_mixed_res:
@@ -307,7 +346,11 @@ def populate(X_array, y_array, path, use_nir=False, end=False, gcs_handler=None,
                     # RGB NIR fusion algorthm still relevant if we have 4 channels
                     # the `use_nir` flag is soely for the AI model to take in a 4 channel input tensor
                     try:
-                        fused_result = rgb_nir_fusion(rgb, use_enhanced_red=True)
+                        fused_result = rgb_nir_fusion(
+                            rgb,
+                            technique=fusion_technique,
+                            alpha=fusion_alpha
+                        )
                     except Exception as e:
                         logger.warning(f"{e}: issue with the rgb nir fusion technique. Skipping for {image_path}")
                         fused_result = rgb
@@ -403,20 +446,26 @@ def dyn_zscore_normalize(img: np.ndarray, no_data_value: float = 0.0) -> np.ndar
 
 
 def rgb_nir_fusion(image_data: np.ndarray[Any, np.dtype[np.integer[Any] | np.floating[Any]]],
-                   use_enhanced_red: bool = False, use_hsv_fusion: bool = False):
+                   technique: str = 'enhanced_red', alpha: float = 0.5):
     """
     Use nir band to "enhance" RGB image. Data fusion technique borrowed from robotics computer vision
 
-    Two flag options:
+    Args:
+        image_data: 4-channel input (RGB+NIR)
+        technique: Fusion method - 'enhanced_red', 'hsv', or 'none'
+        alpha: Blending factor for enhanced_red technique (default 0.5)
 
-    1. enhanced red
-    alpha = 0.5
-    enhanced_red = (1 - alpha) * red + alpha * nir
-    fused = np.stack([enhanced_red, green, blue], axis=-1)
+    Available techniques:
 
-    2. We can try convert the image to a diferent colorspace (RGB -> HSV)
-    and then we combine the brightness channel (V) with the NIR image.
-    We fuse it back together using the inverse of RGB -> HSV matrix. Hue and saturation remain untouched.
+    1. 'enhanced_red': Blend NIR with red channel
+       enhanced_red = (1 - alpha) * red + alpha * nir
+       fused = np.stack([enhanced_red, green, blue], axis=-1)
+
+    2. 'hsv': HSV colorspace fusion
+       Convert RGB -> HSV, combine V channel with NIR, convert back to RGB.
+       Hue and saturation remain untouched.
+
+    3. 'none': Return RGB channels only (no fusion)
     """
     logger.info(f"RGB-NIR fusion called with shape: {image_data.shape}")
 
@@ -432,10 +481,9 @@ def rgb_nir_fusion(image_data: np.ndarray[Any, np.dtype[np.integer[Any] | np.flo
     rgb = image_data[:, :, :3]
     nir = image_data[:, :, 3]
 
-    if use_enhanced_red:
-        logger.info("Using enhanced red fusion method")
+    if technique == 'enhanced_red':
+        logger.info(f"Using enhanced red fusion method with alpha={alpha}")
         blue, green, red = cv2.split(rgb)
-        alpha = 0.5
         enhanced_red = (1 - alpha) * red + alpha * nir
         fused = np.stack([blue, green, enhanced_red], axis=-1)
         logger.debug(f"Enhanced red fusion complete - output shape: {fused.shape}")
@@ -449,7 +497,7 @@ def rgb_nir_fusion(image_data: np.ndarray[Any, np.dtype[np.integer[Any] | np.flo
 
         return fused
 
-    elif use_hsv_fusion:
+    elif technique == 'hsv':
         logger.info("Using HSV fusion method")
         hsv = cv2.cvtColor(rgb, cv2.COLOR_BGR2HSV)
         h, s, v = cv2.split(hsv)
@@ -468,6 +516,10 @@ def rgb_nir_fusion(image_data: np.ndarray[Any, np.dtype[np.integer[Any] | np.flo
 
         return fused
 
+    elif technique == 'none':
+        logger.info("No fusion - returning RGB channels only")
+        return rgb
+
     else:
-        logger.info("No fusion method specified, returning RGB channels only")
+        logger.warning(f"Unknown fusion technique '{technique}', returning RGB only")
         return rgb


### PR DESCRIPTION
**Description of Changes**
- added a module to track the parameters we use for training. creates a unique entry in the new experiments folder with the plot and choices you made. saves out a unique onnx file as well 
- added a preprocess step to simulate our predicted ground sample distance compared to sentiel-2. need to tweak if add enmap
- to prevent overfitting, added drop out and early stopping to training 
- fixed circular import 